### PR TITLE
feat(infra): add cd-deployer SA/Role and kubeconfig generator

### DIFF
--- a/infra/README_KUBE_CONFIG.md
+++ b/infra/README_KUBE_CONFIG.md
@@ -1,0 +1,29 @@
+KUBE_CONFIG generation for GitHub Actions CD
+
+This document explains how to create a least-privilege ServiceAccount and generate a kubeconfig suitable for adding as a GitHub Actions secret named `KUBE_CONFIG`.
+
+Steps (operator/admin):
+
+1. Apply the Role, ServiceAccount and RoleBinding (namespace 'prod')
+
+```bash
+kubectl apply -f infra/k8s/cd-deployer-role.yaml
+```
+
+2. Generate a kubeconfig for the `cd-deployer` service account on your machine that has access to the cluster's kubeconfig and kubectl context.
+
+```bash
+infra/scripts/generate-kubeconfig.sh cd-deployer prod kubeconfig-sa
+```
+
+3. Base64-encode the kubeconfig and add it to your GitHub repository secrets (or organization secrets) as `KUBE_CONFIG`:
+
+```bash
+base64 -w0 kubeconfig-sa > kubeconfig-sa.b64
+# Add via GH CLI
+gh secret set KUBE_CONFIG --body "$(cat kubeconfig-sa.b64)" --repo OWNER/REPO
+```
+
+Notes:
+- The manifest `infra/k8s/cd-deployer-role.yaml` creates a namespaced Role and ServiceAccount scoped to `prod`.
+- Rotate this secret periodically and monitor Actions logs and deploy audit logs.

--- a/infra/k8s/cd-deployer-role.yaml
+++ b/infra/k8s/cd-deployer-role.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prod
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cd-deployer
+  namespace: prod
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cd-deployer-role
+  namespace: prod
+rules:
+  - apiGroups: ["", "apps", "policy", "networking.k8s.io"]
+    resources: ["deployments", "statefulsets", "daemonsets", "services", "configmaps", "secrets", "ingresses", "pods"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["" ]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cd-deployer-binding
+  namespace: prod
+subjects:
+  - kind: ServiceAccount
+    name: cd-deployer
+    namespace: prod
+roleRef:
+  kind: Role
+  name: cd-deployer-role
+  apiGroup: rbac.authorization.k8s.io

--- a/infra/scripts/generate-kubeconfig.sh
+++ b/infra/scripts/generate-kubeconfig.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Usage: ./generate-kubeconfig.sh <serviceaccount> <namespace> <output-file>
+# Example: ./generate-kubeconfig.sh cd-deployer prod kubeconfig-sa
+
+SA_NAME=${1:-cd-deployer}
+NAMESPACE=${2:-prod}
+OUT=${3:-kubeconfig-sa}
+
+CONTEXT=$(kubectl config current-context)
+CLUSTER_NAME=$(kubectl config view -o jsonpath='{.contexts[?(@.name=="'"$CONTEXT"'")].context.cluster}')
+SERVER=$(kubectl config view -o jsonpath='{.clusters[?(@.name=="'"'$CLUSTER_NAME'"'")].cluster.server}')
+
+# get secret name for SA
+SECRET_NAME=$(kubectl -n "$NAMESPACE" get sa "$SA_NAME" -o jsonpath='{.secrets[0].name}')
+CA_DATA=$(kubectl -n "$NAMESPACE" get secret "$SECRET_NAME" -o jsonpath='{.data.ca\.crt}')
+TOKEN=$(kubectl -n "$NAMESPACE" get secret "$SECRET_NAME" -o jsonpath='{.data.token}' | base64 --decode)
+
+# write CA
+CA_FILE=$(mktemp)
+echo "$CA_DATA" | base64 --decode > "$CA_FILE"
+
+# create kubeconfig
+kubectl config --kubeconfig="$OUT" set-cluster "$CLUSTER_NAME" --server="$SERVER" --certificate-authority="$CA_FILE" --embed-certs=true
+kubectl config --kubeconfig="$OUT" set-credentials "$SA_NAME" --token="$TOKEN"
+kubectl config --kubeconfig="$OUT" set-context default --cluster="$CLUSTER_NAME" --user="$SA_NAME" --namespace="$NAMESPACE"
+kubectl config --kubeconfig="$OUT" use-context default
+
+rm -f "$CA_FILE"
+
+echo "wrote $OUT"


### PR DESCRIPTION
Adds a namespaced Role and ServiceAccount for CI/CD deploys, a small script to generate a kubeconfig for that ServiceAccount, and README instructions for adding the base64 KUBE_CONFIG to GitHub Actions secrets.