### PR TITLE
chore(ci): validate KUBE_CONFIG secret workflow

### DIFF
--- a/.github/workflows/validate-kubeconfig.yml
+++ b/.github/workflows/validate-kubeconfig.yml
@@ -1,0 +1,24 @@
+name: Validate KUBE_CONFIG secret
+
+on:
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v3
+      - name: Decode KUBE_CONFIG
+        env:
+          KUBE_CONFIG_B64: ${{ secrets.KUBE_CONFIG }}
+        run: |
+          if [ -z "$KUBE_CONFIG_B64" ]; then echo "KUBE_CONFIG secret not set"; exit 1; fi
+          echo "$KUBE_CONFIG_B64" | base64 --decode > kubeconfig
+          export KUBECONFIG=$(pwd)/kubeconfig
+          kubectl version --client
+          kubectl get ns || true
+          # Try a harmless read in prod namespace to validate access
+          kubectl get pods -n prod --no-headers -o custom-columns=":metadata.name" || true


### PR DESCRIPTION
Adds a manual GitHub Actions workflow to validate the KUBE_CONFIG secret by decoding and running a harmless kubectl read against the prod namespace. Useful to confirm CI secret is correct before running CD.