### PR TITLE
ci: allow manual dispatch for postman-smoke

### DIFF
--- a/.github/workflows/postman-smoke.yml
+++ b/.github/workflows/postman-smoke.yml
@@ -1,6 +1,11 @@
 name: Postman smoke
 
 on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Optional reason for manual dispatch"
+        required: false
   pull_request:
   push:
     branches: [ main ]


### PR DESCRIPTION
Enable workflow_dispatch so CI can be dispatched via API for smoke tests